### PR TITLE
Add JSON schema for Firestore task documents

### DIFF
--- a/task_schema.json
+++ b/task_schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Task",
+  "description": "Schema for task documents in Firestore Todo app",
+  "type": "object",
+  "properties": {
+    "title": {
+      "description": "Title of the task",
+      "type": "string"
+    },
+    "details": {
+      "description": "Optional detailed description of the task",
+      "type": "string"
+    },
+    "completed": {
+      "description": "Whether the task is completed",
+      "type": "boolean"
+    },
+    "created_time": {
+      "description": "Timestamp when the task was created",
+      "type": "string",
+      "format": "date-time"
+    },
+    "user_ref": {
+      "description": "Reference path to the user document",
+      "type": "string"
+    }
+  },
+  "required": ["title", "completed", "created_time", "user_ref"]
+}


### PR DESCRIPTION
Defines a JSON schema for task documents in a Firestore Todo app, including properties like title, details, completed status, creation time, and user reference.